### PR TITLE
Refer to a variable by the correct name

### DIFF
--- a/lib/active_record/connection_adapters/postgis_adapter/rails3/main_adapter.rb
+++ b/lib/active_record/connection_adapters/postgis_adapter/rails3/main_adapter.rb
@@ -266,7 +266,7 @@ module ActiveRecord  # :nodoc:
 
 
         def spatial_column_info(table_name_)
-          SpatialColumnInfo.new(self, quote_string(table_name.to_s)).all
+          SpatialColumnInfo.new(self, quote_string(table_name_.to_s)).all
         end
 
 


### PR DESCRIPTION
The code is triggered when migrating down.
